### PR TITLE
fixed (or avoided) some problem in windows

### DIFF
--- a/primavera/biotools.py
+++ b/primavera/biotools.py
@@ -162,8 +162,6 @@ def blast_sequences(sequences=None, fasta_file=None,
             time.sleep(0.1)
         else:
             break
-    else:
-        print("temp file may not be closed correctly")
     return res
 
 


### PR DESCRIPTION
close_fds=True and stderr=subprocess.PIPE causes an error in Windows.

caught the IOError if the files are not closed correctly.